### PR TITLE
Added config option to control temp dir

### DIFF
--- a/QtWebApp/httpserver/httpconnectionhandler.h
+++ b/QtWebApp/httpserver/httpconnectionhandler.h
@@ -105,7 +105,7 @@ public slots:
 	  Received from from the listener, when the handler shall start processing a new connection.
 	  @param socketDescriptor references the accepted connection.
 	*/
-        void handleConnection(qtwebapp::tSocketDescriptor socketDescriptor);
+	void handleConnection(tSocketDescriptor socketDescriptor);
 	
 private slots:
 	

--- a/QtWebApp/httpserver/httprequest.cpp
+++ b/QtWebApp/httpserver/httprequest.cpp
@@ -19,6 +19,7 @@ HttpRequest::HttpRequest(const HttpServerConfig &cfg)
 	maxSize=cfg.maxRequestSize;
 	maxMultiPartSize=cfg.maxMultipartSize;
 	tempFile=NULL;
+	tmpDir = cfg.tmpDir;
 }
 
 
@@ -174,7 +175,7 @@ void HttpRequest::readBody(QTcpSocket* socket)
 		// Create an object for the temporary file, if not already present
 		if (tempFile == NULL)
 		{
-			tempFile = new QTemporaryFile;
+			tempFile = new QTemporaryFile(tmpDir);
 		}
 		if (!tempFile->isOpen())
 		{
@@ -508,7 +509,7 @@ void HttpRequest::parseMultiPartFile()
 					// this is a file
 					if (!uploadedFile)
 					{
-						uploadedFile=new QTemporaryFile();
+						uploadedFile=new QTemporaryFile(tmpDir);
 						uploadedFile->open();
 					}
 					uploadedFile->write(line);
@@ -533,7 +534,7 @@ HttpRequest::~HttpRequest()
 {
 	foreach(QByteArray key, uploadedFiles.keys())
 	{
-		QTemporaryFile* file=uploadedFiles.value(key);
+		QFile* file=uploadedFiles.value(key);
 		if (file->isOpen())
 		{
 			file->close();
@@ -550,7 +551,7 @@ HttpRequest::~HttpRequest()
 	}
 }
 
-QTemporaryFile* HttpRequest::getUploadedFile(const QByteArray fieldName) const
+QFile* HttpRequest::getUploadedFile(const QByteArray fieldName) const
 {
 	return uploadedFiles.value(fieldName);
 }

--- a/QtWebApp/httpserver/httprequest.h
+++ b/QtWebApp/httpserver/httprequest.h
@@ -137,7 +137,7 @@ public:
       For uploaded files, the method getParameters() returns
       the original fileName as provided by the calling web browser.
     */
-    QTemporaryFile* getUploadedFile(const QByteArray fieldName) const;
+    QFile* getUploadedFile(const QByteArray fieldName) const;
 
     /**
       Get the value of a cookie.
@@ -231,6 +231,9 @@ private:
 
     /** Buffer for collecting characters of request and header lines */
     QByteArray lineBuffer;
+
+    /** Directory for temporary files */
+    QString tmpDir;
 
 };
 

--- a/QtWebApp/httpserver/httpserverconfig.h
+++ b/QtWebApp/httpserver/httpserverconfig.h
@@ -4,6 +4,7 @@
 
 #include <QHostAddress>
 #include <QSettings>
+#include <QStandardPaths>
 
 namespace qtwebapp {
 class HttpConnectionHandlerPool;
@@ -49,6 +50,9 @@ public:
 	
 	/// The file required for SSL support.
 	QString sslKeyFile, sslCertFile;
+
+	// Temporary directory
+	QString tmpDir = QStandardPaths::writableLocation(QStandardPaths::TempLocation);
 	
 private:
 	void parseSettings(const QSettings &settings);


### PR DESCRIPTION
When importing large files using webusb, we often run out of disk space in the /tmp directory. 
By adding a config option to control where temp files are stored, we can avoid this issue.