### PR TITLE
qt6: Fix build with QT_USE_QSTRINGBUILDER

### DIFF
--- a/QtWebApp/httpserver/httprequest.cpp
+++ b/QtWebApp/httpserver/httprequest.cpp
@@ -369,9 +369,11 @@ void HttpRequest::parseMultiPartFile() {
 #endif
 		QTemporaryFile *uploadedFile = nullptr;
 		QByteArray fieldValue;
+		QByteArray boundaryStart = "--" + boundary;
+		QByteArray boundaryEnd = boundary + "--";
 		while (!tempFile->atEnd() && !finished && !tempFile->error()) {
 			QByteArray line = tempFile->readLine(65536);
-			if (line.startsWith("--" + boundary)) {
+			if (line.startsWith(boundaryStart)) {
 				// Boundary found. Until now we have collected 2 bytes too much,
 				// so remove them from the last result
 				if (fileName.isEmpty() && !fieldName.isEmpty()) {
@@ -403,7 +405,7 @@ void HttpRequest::parseMultiPartFile() {
 						qWarning("HttpRequest: format error, unexpected end of file data");
 					}
 				}
-				if (line.contains(boundary + "--")) {
+				if (line.contains(boundaryEnd)) {
 					finished = true;
 				}
 				break;


### PR DESCRIPTION
httprequest.cpp:374:44: error: no matching function for call
    to ‘QByteArray::startsWith(QStringBuilder<char [3], QByteArray>)’
374 |                         if (line.startsWith("--" + boundary)) {

httprequest.cpp:406:50: error: no matching function for call
    to ‘QByteArray::contains(QStringBuilder<QByteArray, char [3]>)’
406 |                                 if (line.contains(boundary + "--")) {

Also we don't change the boundary during the loop so we don't need to
create helper strings every iteration.