### PR TITLE
Qt 6.11 compile fixes

### DIFF
--- a/QtWebApp/CMakeLists.txt
+++ b/QtWebApp/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(qtwebapp_MAJOR 1)
 set(qtwebapp_MINOR 8)
-set(qtwebapp_PATCH 3)
+set(qtwebapp_PATCH 4)
 set(qtwebapp_VERSION ${qtwebapp_MAJOR}.${qtwebapp_MINOR}.${qtwebapp_PATCH})
 
 find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Core Network REQUIRED)

--- a/QtWebApp/httpserver/CMakeLists.txt
+++ b/QtWebApp/httpserver/CMakeLists.txt
@@ -35,8 +35,6 @@ set_target_properties(QtWebAppHttpServer PROPERTIES
 		SOVERSION ${qtwebapp_MAJOR}
 	)
 
-target_compile_definitions(QtWebAppHttpServer PRIVATE CMAKE_QTWEBAPP_SO)
-
 install(TARGETS QtWebAppHttpServer
 		EXPORT QtWebAppTargets
         LIBRARY DESTINATION lib

--- a/QtWebApp/httpserver/httprequest.cpp
+++ b/QtWebApp/httpserver/httprequest.cpp
@@ -153,7 +153,13 @@ void HttpRequest::readBody(QTcpSocket *socket) {
 			tempFile = new QTemporaryFile(tmpDir);
 		}
 		if (!tempFile->isOpen()) {
-			tempFile->open();
+			if (!tempFile->open()) {
+				qWarning("HttpRequest: could not open temp dir");
+				delete tempFile;
+				tempFile = nullptr;
+				status = abort;
+				return;
+			}
 		}
 		// Transfer data in 64kb blocks
 		qint64 fileSize = tempFile->size();
@@ -418,7 +424,11 @@ void HttpRequest::parseMultiPartFile() {
 					// this is a file
 					if (!uploadedFile) {
 						uploadedFile = new QTemporaryFile(tmpDir);
-						uploadedFile->open();
+						if (!uploadedFile->open()) {
+							qCritical("HttpRequest: error opening temp file");
+							delete uploadedFile;
+							return;
+						}
 					}
 					uploadedFile->write(line);
 					if (uploadedFile->error()) {

--- a/QtWebApp/logging/CMakeLists.txt
+++ b/QtWebApp/logging/CMakeLists.txt
@@ -12,7 +12,6 @@ set(logging_SOURCES
 	)
 
 add_library(QtWebAppLogging SHARED ${logging_HEADERS} ${logging_SOURCES})
-target_compile_definitions(QtWebAppLogging PRIVATE CMAKE_QTWEBAPP_SO)
 
 target_include_directories(QtWebAppLogging PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>


### PR DESCRIPTION
- **fix: export qtwebapp::parseNum properly**
- **chore: handle return of QFile::open**
- **chore: bump minor version to 1.8.4**
